### PR TITLE
Display content as a popup or as a new tab

### DIFF
--- a/src/options/components/App/App.tsx
+++ b/src/options/components/App/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import '../../../common.css';
 import { LocalResourceLink } from '../../../components/LocalResourceLink';
 import { LinkedStatus } from '../LinkedStatus/LinkedStatus';
+import { DisplaySettings } from '../DisplaySettings/DisplaySettings';
 
 export const App = () => (
   <div className="container">
@@ -26,6 +27,8 @@ export const App = () => (
             </p>
           </td>
         </tr>
+        <DisplaySettings />
+
       </tbody>
     </table>
     <hr className="mt-5" />

--- a/src/options/components/DisplaySettings/DisplaySettings.tsx
+++ b/src/options/components/DisplaySettings/DisplaySettings.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { storage } from '../../../storage';
+
+
+type AnchorTarget = '_blank' | 'popup'
+
+export const DisplaySettings = () => {
+  const [target, setTarget] = useState<AnchorTarget>()
+
+  useEffect(() => {
+    (async () => {
+      const target = await storage.get('display')
+
+      setTarget(target || '_blank')
+    })();
+  });
+
+  const setNewTarget = async (display: AnchorTarget) => {
+    await storage.set({ display })
+    setTarget(display)
+  }
+
+  return (
+    <tr>
+      <th className="table-secondary">
+        Content Display
+      </th>
+      <td>
+        <div className="form-check">
+          <input className="form-check-input" type="radio" name="NewTab" id="newtab" value="_blank" checked={target === '_blank'} onChange={(e) => setNewTarget(e.target.value as AnchorTarget)} />
+          <label className="form-check-label" htmlFor="newtab">
+            New Tab
+          </label>
+        </div>
+        <div className="form-check">
+          <input className="form-check-input" type="radio" name="Popup" id="popup" value="popup" checked={target === 'popup'} onChange={(e) => setNewTarget(e.target.value as AnchorTarget)} />
+          <label className="form-check-label" htmlFor="popup">
+            Popup
+          </label>
+        </div>
+      </td>
+    </tr>
+  );
+};

--- a/src/popup/components/Item/Item.tsx
+++ b/src/popup/components/Item/Item.tsx
@@ -3,6 +3,7 @@ import { isPopup as isPopupFn } from '../../../utils';
 import { ICON_TYPE } from '../../constants';
 import './styles.pcss';
 import { setHighlight } from './utils';
+import { storage } from '../../../storage';
 
 const getType = (block: SearchApi.Block) =>
   'debug-block-' + block.type.replaceAll('_', '-');
@@ -21,13 +22,11 @@ export default function Item({
       <>{icon.value}</>
     ) : (
       <img
-        className={`page-icon ${
-          icon.value.match(/^https?:\/\/.+\.svg/) ? 'svg' : ''
-        }`}
+        className={`page-icon ${icon.value.match(/^https?:\/\/.+\.svg/) ? 'svg' : ''
+          }`}
         src={icon.value}
       />
     );
-  const isPopup = useMemo(isPopupFn, []);
 
   let dirElements: React.ReactNode | undefined = undefined;
   if (dirs.length > 0) {
@@ -65,9 +64,15 @@ export default function Item({
     >
       <a
         className="url"
-        {...(isPopup && { target: '_blank' })}
-        href={url}
-        onClick={() => console.info(block)}
+        href="javascript:void(0)"
+        onClick={async (e) => {
+          e.preventDefault()
+          const target = await storage.get("display")
+          console.info(block)
+          // TODO: maybe add a section in settings for popup size customization?
+          window.open(url, target, target === 'popup' ? 'width=800,height=1000;top:0px' : undefined)
+        }
+        }
       >
         <div className="page-icon-container">
           <div className="page-icon-wrapper">{iconElement}</div>

--- a/src/popup/components/Item/Item.tsx
+++ b/src/popup/components/Item/Item.tsx
@@ -1,5 +1,4 @@
-import React, { useMemo } from 'react';
-import { isPopup as isPopupFn } from '../../../utils';
+import React from 'react';
 import { ICON_TYPE } from '../../constants';
 import './styles.pcss';
 import { setHighlight } from './utils';


### PR DESCRIPTION
I added a section to the extension's option page that allows the user to choose whether to display the clicked search element as a new tab or popup. Currently, the popup window is fixed in size and opens on the left side of the screen. However, in the future, It could be useful to add more customizable settings that would allow the user to choose the exact width and height of the popup window.

My code may not be following React's best practices, or it may not be good at all since I am not experienced in React development, but I wanted to contribute to this project as it is a really useful and well written extension.