### PR TITLE
fix 401 handling

### DIFF
--- a/src/popup/components/Callout/EmptySearchResults/EmptySearchResults.tsx
+++ b/src/popup/components/Callout/EmptySearchResults/EmptySearchResults.tsx
@@ -1,6 +1,8 @@
+import { AxiosError } from 'axios';
 import React, { useEffect, useState } from 'react';
 import { axios } from '../../../../axios';
 import { NOTION_BASE_URL } from '../../../../constants';
+import { handleError } from '../../../../utils';
 import './styles.pcss';
 
 // TODO: test
@@ -13,9 +15,16 @@ export const EmptySearchResultsCallout = ({
 
   useEffect(() => {
     (async () => {
-      // 見せられなくても致命的でないのでエラーハンドリングしない
-      const res = (await axios.post<GetWorkspacesApiResponse>('/getSpaces'))
-        .data;
+      let res: GetWorkspacesApiResponse;
+      try {
+        res = (await axios.post<GetWorkspacesApiResponse>('/getSpaces')).data;
+      } catch (error) {
+        handleError(
+          error instanceof AxiosError ? 'Network error' : error + '',
+          error,
+        );
+        throw error; // TODO
+      }
 
       // TODO: userId 手に入れたら改修の必要あり
       let isFound = false;

--- a/src/popup/search/search.ts
+++ b/src/popup/search/search.ts
@@ -131,6 +131,7 @@ export const search = async ({
       throw new Error(`Unknown sort option: ${sortBy}`);
   }
 
+  // TODO: /search doesn't return 401 … 😓
   const res = (
     await axios.post<SearchApiResponse>(PATH, {
       type: 'BlocksInSpace',


### PR DESCRIPTION
- `/search` doesn't return 401
- fall back at EmptySeachResults